### PR TITLE
Added System.Runtime.Serialization to frameworkAssemblies

### DIFF
--- a/Enumeration.nuspec
+++ b/Enumeration.nuspec
@@ -11,6 +11,9 @@
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>A utility class. Common uses include Java-like enumerations, dispatch table, flyweight, and drop-down list items/select options.</description>
         <tags>utility enumeration</tags>
+        <frameworkAssemblies>
+            <frameworkAssembly assemblyName="System.Runtime.Serialization"  />
+        </frameworkAssemblies>
     </metadata>
     <files>
         <file src="Enumeration.cs" target="content\Headspring\Enumeration.cs" />


### PR DESCRIPTION
When you add the NuGet package to a project that doesn't have `System.Runtime.Serialization` referenced, things break as it is...