### PR TITLE
Added virtual ValueEquals method

### DIFF
--- a/Enumeration.cs
+++ b/Enumeration.cs
@@ -100,7 +100,7 @@ namespace Headspring
 
         public bool Equals(TEnumeration other)
         {
-            return other != null && Value.Equals(other.Value);
+            return other != null && ValueEquals(other.Value);
         }
 
         public override int GetHashCode()
@@ -149,12 +149,17 @@ namespace Headspring
 
         public static bool TryParse(TValue value, out TEnumeration result)
         {
-            return TryParse(e => e.Value.Equals(value), out result);
+            return TryParse(e => e.ValueEquals(value), out result);
         }
 
         public static bool TryParse(string displayName, out TEnumeration result)
         {
             return TryParse(e => e.DisplayName == displayName, out result);
+        }
+
+        protected virtual bool ValueEquals(TValue value)
+        {
+            return Value.Equals(value);
         }
     }
 }


### PR DESCRIPTION
This will allow you to easily do custom equality checking on value, like this

```csharp
public abstract class StringEnumeration<TEnumeration> : Enumeration<TEnumeration, string>
    where TEnumeration : StringEnumeration<TEnumeration>
{
    protected StringEnumeration(string value, string displayName, StringComparison comparison)
        : base(value, displayName)
    {
        Comparison = comparison;
    }

    public StringComparison Comparison { get; private set; }

    protected override bool ValueEquals(string value)
    {
        return Value.Equals(value, Comparison);
    }
}
```

Notice the `StringComparison` constructor argument. This will allow you to do culture/casing customization of string value comparison.