### PR TITLE
specify which argument is null in the argument null exception

### DIFF
--- a/Enumeration.cs
+++ b/Enumeration.cs
@@ -46,7 +46,7 @@ namespace Headspring
         {
             if (value == null)
             {
-                throw new ArgumentNullException();
+                throw new ArgumentNullException(nameof(value));
             }
 
             _value = value;


### PR DESCRIPTION
Simple PR to specify which null argument causes the ArgumentNullException thrown in the constructor of Enumeration.

I was using the Enumeration class in a project with FxCop which stopped the build because of CA2208.  Calling ArgumentNullException(nameof(value)) instead of the parameter-less constructor provides a better exception message.

see for reference: 
https://msdn.microsoft.com/en-us/library/system.argumentnullexception(v=vs.110).aspx
CA2208: https://msdn.microsoft.com/en-us/library/ms182347.aspx